### PR TITLE
Corrections au thème Calypso: les feuilles de style sont nécessaires

### DIFF
--- a/src/themes/calypso/styles/_global-styles.scss
+++ b/src/themes/calypso/styles/_global-styles.scss
@@ -1,0 +1,23 @@
+// Add any global css for the theme here
+
+// imports the base global style
+@import '../../../styles/_global-styles.scss';
+
+.facet-filter, .setting-option {
+  background-color: var(--bs-light);
+  border-radius: var(--bs-border-radius);
+
+  &.p-3 {
+    // Needs !important because the original bootstrap class uses it
+    padding-top: 0.5rem !important;
+    padding-bottom: 0.5rem !important;
+  }
+
+  .badge-secondary {
+    background-color: var(--bs-primary);
+  }
+
+  h5 {
+    font-size: 1.1rem
+  }
+}

--- a/src/themes/calypso/styles/_theme_css_variable_overrides.scss
+++ b/src/themes/calypso/styles/_theme_css_variable_overrides.scss
@@ -1,0 +1,11 @@
+// Override or add CSS variables for your theme here
+
+:root {
+  --ds-header-logo-height: 40px;
+  --ds-banner-text-background: rgba(0, 0, 0, 0.45);
+  --ds-banner-background-gradient-width: 300px;
+  --ds-home-news-link-color: #{$green};
+  --ds-home-news-link-hover-color: #{darken($green, 15%)};
+  --ds-header-navbar-border-bottom-color: #{$green};
+}
+

--- a/src/themes/calypso/styles/_theme_sass_variable_overrides.scss
+++ b/src/themes/calypso/styles/_theme_sass_variable_overrides.scss
@@ -1,0 +1,41 @@
+// DSpace works with CSS variables for its own components, and has a mapping of all bootstrap Sass
+// variables to CSS equivalents (see src/styles/_bootstrap_variables_mapping.scss). However Bootstrap
+// still uses Sass variables internally. So if you want to override bootstrap (or other sass
+// variables) you can do so here. Their CSS counterparts will include the changes you make here
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200;0,300;0,400;0,600;0,700;0,800;1,200;1,300;1,400;1,600;1,700;1,800&display=swap');
+
+$font-family-sans-serif: 'Nunito', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+
+$navbar-dark-color: #FFFFFF;
+
+/* Reassign color vars to semantic color scheme */
+$blue: #2b4e72 !default;
+$green: #92C642 !default;
+$cyan: #207698 !default;
+$yellow: #ec9433 !default;
+$red: #CF4444 !default;
+$dark: #43515f !default;
+
+$gray-800: #343a40 !default;
+$gray-700: #495057 !default;
+$gray-400: #ced4da !default;
+$gray-100: #f8f9fa !default;
+
+$body-color: $gray-800 !default;                    // Bootstrap $gray-800
+
+$table-accent-bg: $gray-100 !default;   // Bootstrap $gray-100
+$table-hover-bg: $gray-400 !default;   // Bootstrap $gray-400
+
+$yiq-contrasted-threshold:  170 !default;
+
+$theme-colors: (
+        primary: $dark,
+        secondary: $gray-700,
+        success: $green,
+        info: $cyan,
+        warning: $yellow,
+        danger: $red,
+        light: $gray-100,
+        dark: $dark
+) !default;

--- a/src/themes/calypso/styles/theme.scss
+++ b/src/themes/calypso/styles/theme.scss
@@ -1,6 +1,5 @@
 // This file combines the other scss files in to one. You usually shouldn't edit this file directly
 
-/*
 @import './_theme_sass_variable_overrides.scss';
 @import '../../../styles/_variables.scss';
 @import '../../../styles/_mixins.scss';
@@ -11,4 +10,3 @@
 @import '../../../styles/bootstrap_variables_mapping.scss';
 @import '../../../styles/_truncatable-part.component.scss';
 @import './_global-styles.scss';
-*/


### PR DESCRIPTION
À cause d'une incompréhension des caches Angular, mes ajouts pour un thème Calypso n'étaient pas suffisants. Des feuilles de styles de base sont nécessaires. J'ai copié celles du thème Espace.