### PR TITLE
Configuration applicative locale dans un fichier config.calypso.yml

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,2 +1,3 @@
 config.*.yml
+!config.calypso.yml
 !config.example.yml

--- a/config/config.calypso.yml
+++ b/config/config.calypso.yml
@@ -1,0 +1,248 @@
+#############################################################################
+# Fichier de configuration local, avec des propriétés spécifiques
+# à l'environnement d'exécution. L'ordre de priorité des configurations
+# est:
+#
+# 1) Variables d'environnement
+# 2) Fichier config/config.calypso.yml
+# 3) Fichier config/config.[prod|dev|test].yml
+# 4) Fichier config/config.yml
+#
+# À noter qu'une variable d'environnement est nécessaire pour que le fichier
+# .local soit lu:
+#
+# export DSPACE_APP_CONFIG_PATH=config/config.calypso.yml
+#
+# Voir config/config.server.ts pour les détails
+#############################################################################
+
+
+# On va définir dans ce fichier tout ce qui est commun à l'application
+# Calypso, peu importe son environnement d'exécution
+
+# Form settings
+form:
+  # Sets the spellcheck textarea attribute value
+  spellCheck: true
+  # NOTE: Map server-side validators to comparative Angular form validators
+  validatorMap:
+    required: required
+    regex: pattern
+
+# Notification settings
+notifications:
+  rtl: false
+  position:
+    - top
+    - right
+  maxStack: 8
+  # NOTE: after how many seconds notification is closed automatically. If set to zero notifications are not closed automatically
+  timeOut: 5000 # 5 second
+  clickToClose: true
+  # NOTE: 'fade' | 'fromTop' | 'fromRight' | 'fromBottom' | 'fromLeft' | 'rotate' | 'scale'
+  animate: scale
+
+# Submission settings
+submission:
+  autosave:
+    # NOTE: which metadata trigger an autosave
+    metadata: []
+    # NOTE: after how many time (milliseconds) submission is saved automatically
+    # eg. timer: 5 * (1000 * 60); // 5 minutes
+    timer: 0
+  icons:
+    metadata:
+      # NOTE: example of configuration
+      #   # NOTE: metadata name
+      # - name: dc.author
+      #   # NOTE: fontawesome (v5.x) icon classes and bootstrap utility classes can be used
+      #   style: fas fa-user
+      - name: dc.author
+        style: fas fa-user
+      # default configuration
+      - name: default
+        style: ''
+    authority:
+      confidence:
+        # NOTE: example of configuration
+        #   # NOTE: confidence value
+        # - name: dc.author
+        #   # NOTE: fontawesome (v5.x) icon classes and bootstrap utility classes can be used
+        #   style: fa-user
+        - value: 600
+          style: text-success
+        - value: 500
+          style: text-info
+        - value: 400
+          style: text-warning
+        # default configuration
+        - value: default
+          style: text-muted
+
+#  Default Language in which the UI will be rendered if the user's browser language is not an active language
+defaultLanguage: fr
+
+# Languages. DSpace Angular holds a message catalog for each of the following languages.
+# When set to active, users will be able to switch to the use of this language in the user interface.
+languages:
+  - code: fr
+    label: Français
+    active: true
+  - code: en
+    label: English
+    active: true
+
+
+# Browse-By Pages
+browseBy:
+  # Amount of years to display using jumps of one year (current year - oneYearLimit)
+  oneYearLimit: 10
+  # Limit for years to display using jumps of five years (current year - fiveYearLimit)
+  fiveYearLimit: 30
+  # The absolute lowest year to display in the dropdown (only used when no lowest date can be found for all items)
+  defaultLowerLimit: 1900
+  # If true, thumbnail images for items will be added to BOTH search and browse result lists.
+  showThumbnails: true
+  # The number of entries in a paginated browse results list.
+  # Rounded to the nearest size in the list of selectable sizes on the
+  # settings menu.
+  pageSize: 20
+
+communityList:
+  # No. of communities to list per expansion (show more)
+  pageSize: 20
+
+homePage:
+  recentSubmissions:
+    # The number of item showing in recent submission components
+    pageSize: 5
+    # Sort record of recent submission
+    sortField: 'dc.date.accessioned'
+  topLevelCommunityList:
+    # No. of communities to list per page on the home page
+    # This will always round to the nearest number from the list of page sizes. e.g. if you set it to 7 it'll use 10
+    pageSize: 5
+
+# Item Config
+item:
+  edit:
+    undoTimeout: 10000 # 10 seconds
+  # Show the item access status label in items lists
+  showAccessStatuses: false
+  bitstream:
+    # Number of entries in the bitstream list in the item view page.
+    # Rounded to the nearest size in the list of selectable sizes on the
+    # settings menu.  See pageSizeOptions in 'pagination-component-options.model.ts'.
+    pageSize: 5
+
+# Collection Page Config
+collection:
+  edit:
+    undoTimeout: 10000 # 10 seconds
+
+# Theme Config
+themes:
+  # Add additional themes here. In the case where multiple themes match a route, the first one
+  # in this list will get priority. It is advisable to always have a theme that matches
+  # every route as the last one
+  #
+  # # A theme with a handle property will match the community, collection or item with the given
+  # # handle, and all collections and/or items within it
+  # - name: 'custom',
+  #   handle: '10673/1233'
+  #
+  # # A theme with a regex property will match the route using a regular expression. If it
+  # # matches the route for a community or collection it will also apply to all collections
+  # # and/or items within it
+  # - name: 'custom',
+  #   regex: 'collections\/e8043bc2.*'
+  #
+  # # A theme with a uuid property will match the community, collection or item with the given
+  # # ID, and all collections and/or items within it
+  # - name: 'custom',
+  #   uuid: '0958c910-2037-42a9-81c7-dca80e3892b4'
+  #
+  # # The extends property specifies an ancestor theme (by name). Whenever a themed component is not found
+  # # in the current theme, its ancestor theme(s) will be checked recursively before falling back to default.
+  # - name: 'custom-A',
+  #   extends: 'custom-B',
+  #   # Any of the matching properties above can be used
+  #   handle: '10673/34'
+  #
+  # - name: 'custom-B',
+  #   extends: 'custom',
+  #   handle: '10673/12'
+  #
+  # # A theme with only a name will match every route
+  # name: 'custom'
+  #
+  # # This theme will use the default bootstrap styling for DSpace components
+  # - name: BASE_THEME_NAME
+  #
+
+  - name: calypso
+    extends: dspace
+    headTags:
+    - tagName: link
+      attributes:
+        rel: icon
+        href: assets/calypso/images/favicons/favicon.ico
+        sizes: any
+
+  - name: dspace
+    headTags:
+    - tagName: link
+      attributes:
+        rel: icon
+        href: assets/dspace/images/favicons/favicon.ico
+        sizes: any
+    - tagName: link
+      attributes:
+        rel: icon
+        href: assets/dspace/images/favicons/favicon.svg
+        type: image/svg+xml
+    - tagName: link
+      attributes:
+        rel: apple-touch-icon
+        href: assets/dspace/images/favicons/apple-touch-icon.png
+    - tagName: link
+      attributes:
+        rel: manifest
+        href: assets/dspace/images/favicons/manifest.webmanifest
+
+# The default bundles that should always be displayed as suggestions when you upload a new bundle
+bundle:
+  standardBundles: [ ORIGINAL, THUMBNAIL, LICENSE ]
+
+# Whether to enable media viewer for image and/or video Bitstreams (i.e. Bitstreams whose MIME type starts with 'image' or 'video').
+# For images, this enables a gallery viewer where you can zoom or page through images.
+# For videos, this enables embedded video streaming
+mediaViewer:
+  image: false
+  video: false
+
+# Whether the end user agreement is required before users use the repository.
+# If enabled, the user will be required to accept the agreement before they can use the repository.
+# And whether the privacy statement should exist or not.
+info:
+  enableEndUserAgreement: true
+  enablePrivacyStatement: true
+
+# Whether to enable Markdown (https://commonmark.org/) and MathJax (https://www.mathjax.org/)
+# display in supported metadata fields. By default, only dc.description.abstract is supported.
+markdown:
+  enabled: false
+  mathjax: false
+
+# Which vocabularies should be used for which search filters
+# and whether to show the filter in the search sidebar
+# Take a look at the filter-vocabulary-config.ts file for documentation on how the options are obtained
+vocabularies:
+  - filter: 'subject'
+    vocabulary: 'srsc'
+    enabled: true
+
+# Default collection/community sorting order at Advanced search, Create/update community and collection when there are not a query. 
+comcolSelectionSort:
+  sortField: 'dc.title'
+  sortDirection: 'ASC'

--- a/src/themes/calypso/styles/_global-styles.scss
+++ b/src/themes/calypso/styles/_global-styles.scss
@@ -1,0 +1,23 @@
+// Add any global css for the theme here
+
+// imports the base global style
+@import '../../../styles/_global-styles.scss';
+
+.facet-filter, .setting-option {
+  background-color: var(--bs-light);
+  border-radius: var(--bs-border-radius);
+
+  &.p-3 {
+    // Needs !important because the original bootstrap class uses it
+    padding-top: 0.5rem !important;
+    padding-bottom: 0.5rem !important;
+  }
+
+  .badge-secondary {
+    background-color: var(--bs-primary);
+  }
+
+  h5 {
+    font-size: 1.1rem
+  }
+}

--- a/src/themes/calypso/styles/_theme_css_variable_overrides.scss
+++ b/src/themes/calypso/styles/_theme_css_variable_overrides.scss
@@ -1,0 +1,11 @@
+// Override or add CSS variables for your theme here
+
+:root {
+  --ds-header-logo-height: 40px;
+  --ds-banner-text-background: rgba(0, 0, 0, 0.45);
+  --ds-banner-background-gradient-width: 300px;
+  --ds-home-news-link-color: #{$green};
+  --ds-home-news-link-hover-color: #{darken($green, 15%)};
+  --ds-header-navbar-border-bottom-color: #{$green};
+}
+

--- a/src/themes/calypso/styles/_theme_sass_variable_overrides.scss
+++ b/src/themes/calypso/styles/_theme_sass_variable_overrides.scss
@@ -1,0 +1,41 @@
+// DSpace works with CSS variables for its own components, and has a mapping of all bootstrap Sass
+// variables to CSS equivalents (see src/styles/_bootstrap_variables_mapping.scss). However Bootstrap
+// still uses Sass variables internally. So if you want to override bootstrap (or other sass
+// variables) you can do so here. Their CSS counterparts will include the changes you make here
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200;0,300;0,400;0,600;0,700;0,800;1,200;1,300;1,400;1,600;1,700;1,800&display=swap');
+
+$font-family-sans-serif: 'Nunito', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+
+$navbar-dark-color: #FFFFFF;
+
+/* Reassign color vars to semantic color scheme */
+$blue: #2b4e72 !default;
+$green: #92C642 !default;
+$cyan: #207698 !default;
+$yellow: #ec9433 !default;
+$red: #CF4444 !default;
+$dark: #43515f !default;
+
+$gray-800: #343a40 !default;
+$gray-700: #495057 !default;
+$gray-400: #ced4da !default;
+$gray-100: #f8f9fa !default;
+
+$body-color: $gray-800 !default;                    // Bootstrap $gray-800
+
+$table-accent-bg: $gray-100 !default;   // Bootstrap $gray-100
+$table-hover-bg: $gray-400 !default;   // Bootstrap $gray-400
+
+$yiq-contrasted-threshold:  170 !default;
+
+$theme-colors: (
+        primary: $dark,
+        secondary: $gray-700,
+        success: $green,
+        info: $cyan,
+        warning: $yellow,
+        danger: $red,
+        light: $gray-100,
+        dark: $dark
+) !default;

--- a/src/themes/calypso/styles/theme.scss
+++ b/src/themes/calypso/styles/theme.scss
@@ -1,6 +1,5 @@
 // This file combines the other scss files in to one. You usually shouldn't edit this file directly
 
-/*
 @import './_theme_sass_variable_overrides.scss';
 @import '../../../styles/_variables.scss';
 @import '../../../styles/_mixins.scss';
@@ -11,4 +10,3 @@
 @import '../../../styles/bootstrap_variables_mapping.scss';
 @import '../../../styles/_truncatable-part.component.scss';
 @import './_global-styles.scss';
-*/


### PR DESCRIPTION
Le fichier config/config.calypso.yml est lu si on définit une variable d'environnement "export DSPACE_APP_CONFIG_PATH=config/config.calypso.yml".

Pour qu'on puisse partager ces configurations, je l'inclus dans le repo. Ça demande toutefois de modifier le .gitignore de ce dossier, mais ça ne devrait pas être trop difficile à maintenir avec l'évolution de DSpace.

Pour tester, ne mettre que les configurations serveurs dans config.prod.yml ou config.text.yml (voir les exemples de Martin dans Teams), puis faire yarn start.