### PR TITLE
Paramètre lang= pour appeler Mirador

### DIFF
--- a/src/app/item-page/mirador-viewer/mirador-viewer.component.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.component.ts
@@ -9,6 +9,7 @@ import { isPlatformBrowser } from '@angular/common';
 import { MiradorViewerService } from './mirador-viewer.service';
 import { HostWindowService, WidthCategory } from '../../shared/host-window.service';
 import { BundleDataService } from '../../core/data/bundle-data.service';
+import { LocaleService } from '../../core/locale/locale.service';
 
 @Component({
   selector: 'ds-mirador-viewer',
@@ -58,6 +59,7 @@ export class MiradorViewerComponent implements OnInit {
               private bitstreamDataService: BitstreamDataService,
               private bundleDataService: BundleDataService,
               private hostWindowService: HostWindowService,
+              private localeService: LocaleService,
               @Inject(PLATFORM_ID) private platformId: any) {
   }
 
@@ -86,6 +88,7 @@ export class MiradorViewerComponent implements OnInit {
     if (this.notMobile) {
       viewerPath += '&notMobile=true';
     }
+    viewerPath += '&lang=' + this.localeService.getCurrentLanguageCode();
 
     // TODO: Should the query term be trusted here?
     return this.sanitizer.bypassSecurityTrustResourceUrl(viewerPath);

--- a/src/mirador-viewer/config.default.js
+++ b/src/mirador-viewer/config.default.js
@@ -23,12 +23,14 @@ const searchOption = params.get('searchable');
 const query = params.get('query');
 const multi = params.get('multi');
 const notMobile = params.get('notMobile');
+const langParam = params.get('lang');
 
 let windowSettings = {};
 let sidbarPanel = 'info';
 let defaultView = 'single';
 let multipleItems = false;
 let thumbNavigation = 'off';
+let lang = 'en' // Default to english, but should not happen
 
 windowSettings.manifestId = manifest;
 
@@ -51,6 +53,9 @@ windowSettings.manifestId = manifest;
       }
     }
   }
+  if ( langParam !== 'null' ) {
+    lang = langParam;
+  }
 })();
 
 (Mirador.viewer(
@@ -59,6 +64,7 @@ windowSettings.manifestId = manifest;
       mainMenuSettings: {
         show: true
       },
+      language: lang,       // The default language set in the application
       thumbnailNavigation: {
         defaultPosition: thumbNavigation, // Which position for the thumbnail navigation to be be displayed. Other possible values are "far-bottom" or "far-right"
         displaySettings: true, // Display the settings for this in WindowTopMenu


### PR DESCRIPTION
Un petit changement tout simple pour que l'interface de Mirador soit dans la même langue que celle de DSpace.

Un paramètre lang= est ajouté à l'URL du iFrame, et le javascript dans le HTML tient compte de ceci.

Ce changement devrait être poussé vers DSpace. À discuter d'abord avec les contributeurs IIIF car d'autres changements pourraient être apportés.

Pour tester:
- ajuster le config.local.js de Mirador en fonction des changements à config.default.js (ou voir le fichier de Martin dans Teams)
- yarn build:mirador
- yarn start

Naviguer dans DSpace en français, voir une image avec Mirador, l'interface devrait être en français. Changer de langue pour l'anglais (DSpace), puis ouvrir une image avec Mirador, l'interface devrait être en anglais.