### PR TITLE
Remplacer le mot image par document dans l'onglet de la page d'item

### DIFF
--- a/src/themes/collspec/assets/i18n/en.json5
+++ b/src/themes/collspec/assets/i18n/en.json5
@@ -9,7 +9,7 @@
 
   "repository.title.prefix": "Special Collections :: ",
 
-  "collspec.onglet-fichier": "Image",
+  "collspec.onglet-fichier": "Document",
   "collspec.onglet-notice": "Full record",
   "collspec.return": "Back",
   "collspec.consulter": "View",

--- a/src/themes/collspec/assets/i18n/fr.json5
+++ b/src/themes/collspec/assets/i18n/fr.json5
@@ -9,7 +9,7 @@
 
   // "repository.title.prefix": "DSpace Angular :: ",
   "repository.title.prefix": "Collections spéciales :: ",
-  "collspec.onglet-fichier": "Image",
+  "collspec.onglet-fichier": "Document",
   "collspec.onglet-notice": "Notice complète",
   "collspec.return": "Retour",
   "collspec.consulter": "Consulter",


### PR DESCRIPTION
Remplacer le mot image par document dans l'onglet de la page d'item du thème collspec.