### PR TITLE
Cacher le description du manifest IIIF + Style d'affichage des métadonnées dans Mirador

### DIFF
--- a/src/mirador-viewer/mirador.html
+++ b/src/mirador-viewer/mirador.html
@@ -17,6 +17,57 @@
     .mirador-window-top-bar .mirador-window-close {
       order: 4;
     }
+	/* Cacher le description du niveau manifest dans Mirador */
+	p.MuiTypography-root.MuiTypography-body1 span.mirador-third-party-html {
+      display: none !important;
+    }
+	/* ── Panneau de métadonnées : base commune ── */
+	.mirador-companion-area-left .mirador-companion-windows dl,
+	.mirador-companion-area-left .mirador-companion-windows dt,
+	.mirador-companion-area-left .mirador-companion-windows dd {
+	  -webkit-text-size-adjust: 100%;
+	  -webkit-font-smoothing: antialiased;
+	  font-family: Lato, Helvetica, Arial, sans-serif;
+	  color: rgba(0, 0, 0, 0.87);
+	  word-break: break-word;
+	  box-sizing: border-box;
+	  border: 0 solid #e2e8f0;
+	  margin: 0;
+	  user-select: auto;
+	  cursor: auto;
+	  scroll-margin-top: 12rem;
+	  --transition-duration: 250ms;
+	}
+	/* ── dl ── */
+	.mirador-companion-area-left .mirador-companion-windows dl {
+	  font-size: 1rem;
+	  line-height: 2;
+	}
+	/* ── dt (libellés) ── */
+	.mirador-companion-area-left .mirador-companion-windows dt {
+	  font-size: 0.95rem;
+	  font-weight: 700;
+	  letter-spacing: 0.02em;
+	  line-height: 1.375;
+	  margin-top: 0.5rem;
+	  color: #006780;
+	}
+	/* ── dd (valeurs) ── */
+	.mirador-companion-area-left .mirador-companion-windows dd {
+	  font-size: 0.95rem;
+	  font-weight: 400;
+	  line-height: 1.6em;
+	  letter-spacing: 0em;
+	  color: rgba(116, 116, 116, 1);
+	  padding-bottom: 0.5rem;
+	  margin-bottom: 0.5em;
+	  border-bottom: 1px solid rgba(232, 232, 232, 1);
+	}
+	/* ── dd: Supprimer la bordure du dernier élément ── */
+	.mirador-companion-area-left .mirador-companion-windows dd:last-child {
+	  border-bottom: none;
+	  padding-bottom: 0;
+	}
   </style>
 </head>
 <body>


### PR DESCRIPTION
Cacher le description de niveau supérieur du manifest IIIF + style d'affichage des métadonnées dans Mirador.

Comme Mirador est un iframe dans l'installation de DSpace, j'ai ajouté les styles directement dans 'src/mirador-viewer/mirador.html'. S'il y a une meilleure façon de le faire, on va réviser.