### PR TITLE
Ajout du support des liens directs vers une page spécifique dans Mirador via le paramètre 'page'

### DIFF
--- a/src/app/item-page/mirador-viewer/mirador-viewer.component.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.component.ts
@@ -34,6 +34,10 @@ import {
 } from '../../shared/host-window.service';
 import { MiradorViewerService } from './mirador-viewer.service';
 
+
+// NIMA 2026-05-19 : ajout pour pointer vers une page spécifique dans le document (URL)
+import { ActivatedRoute } from '@angular/router';
+
 @Component({
   selector: 'ds-mirador-viewer',
   styleUrls: ['./mirador-viewer.component.scss'],
@@ -82,6 +86,7 @@ export class MiradorViewerComponent implements OnInit {
 
   constructor(private sanitizer: DomSanitizer,
               private viewerService: MiradorViewerService,
+			  private route: ActivatedRoute, // NIMA - 2026-05-19
               private bitstreamDataService: BitstreamDataService,
               private bundleDataService: BundleDataService,
               private hostWindowService: HostWindowService,
@@ -96,9 +101,16 @@ export class MiradorViewerComponent implements OnInit {
     // The path to the REST manifest endpoint.
     const manifestApiEndpoint = encodeURIComponent(environment.rest.baseUrl + '/iiif/'
       + this.object.id + '/manifest');
+	// NIMA - 2026-05-19 ajout pour trouver la page par numéro de canvas dans le lien
+	const page = this.route.snapshot.queryParamMap.get('page');
     // The Express path to Mirador viewer.
     let viewerPath = `${environment.ui.nameSpace}${environment.ui.nameSpace.length > 1 ? '/' : ''}`
       + `iiif/mirador/index.html?manifest=${manifestApiEndpoint}`;
+	  
+	// NIMA - 2026-05-19
+	if (page) {
+	  viewerPath += '&page=' + page;
+	}
     if (this.searchable) {
       // Tell the viewer add search to menu.
       viewerPath += '&searchable=' + this.searchable;

--- a/src/mirador-viewer/config.local.js
+++ b/src/mirador-viewer/config.local.js
@@ -34,6 +34,8 @@ const query = params.get('query');
 const multi = params.get('multi');
 const notMobile = params.get('notMobile');
 const langParam = params.get('lang');
+// NIMA - 2026-05-19 : ajout pour le lien vers une page par numéro de canvas
+const page = parseInt(params.get('page') || '1', 10);
 //const endpointUrl = 'http://127.0.0.1:3000/annotations';
 
 let windowSettings = {};
@@ -47,6 +49,8 @@ let manifestId = manifest;
 
 
 windowSettings.manifestId = manifest;
+// NIMA 2026-05-19
+windowSettings.canvasIndex = page - 1;
 //windowSettings.view = 'book';
 
 (() => {


### PR DESCRIPTION
Ajout du support des liens directs vers une page spécifique dans Mirador via le paramètre 'page'

Le format du lien vers une page donnée sera : 

https://collections-speciales.bib.umontreal.ca/items/<uuid>?page=<numéro_de_page>