### PR TITLE
feat(i18n): ajout des clés de traduction pour les valeurs du filtre de langue

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -4428,7 +4428,7 @@
 
   "repository.title": "Collections spéciales",
 
-  "repository.title.prefix": "Special Collections ",
+  "repository.title.prefix": "Special Collections :: ",
 
   "resource-policies.add.button": "Add",
 
@@ -7433,4 +7433,28 @@
   "search.filters.filter.language.head": "Language",
 
   "collspec.page-udem": "About",
+
+  "search.filters.language.fra": "French",
+
+  "search.filters.language.fre": "French",
+
+  "search.filters.language.frm": "Middle French",
+
+  "search.filters.language.fro": "Old French",
+
+  "search.filters.language.eng": "English",
+
+  "search.filters.language.enm": "Middle English",
+
+  "search.filters.language.deu": "German",
+
+  "search.filters.language.spa": "Spanish",
+
+  "search.filters.language.ita": "Italian",
+
+  "search.filters.language.por": "Portuguese",
+
+  "search.filters.language.lat": "Latin",
+
+  "search.filters.language.alg": "Algonquian languages",
 }

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -4428,7 +4428,7 @@
 
   "repository.title": "Collections spéciales",
 
-  "repository.title.prefix": "Collections spéciales ",
+  "repository.title.prefix": "Collections spéciales :: ",
 
   "resource-policies.add.button": "Ajouter",
 
@@ -7447,4 +7447,28 @@
   "search.filters.filter.language.head": "Langue",
 
   "collspec.page-udem": "À propos",
+
+  "search.filters.language.fra": "Français",
+
+  "search.filters.language.fre": "Français",
+
+  "search.filters.language.frm": "Français moyen",
+
+  "search.filters.language.fro": "Ancien français",
+
+  "search.filters.language.eng": "Anglais",
+
+  "search.filters.language.enm": "Moyen anglais",
+
+  "search.filters.language.deu": "Allemand",
+
+  "search.filters.language.spa": "Espagnol",
+
+  "search.filters.language.ita": "Italien",
+
+  "search.filters.language.por": "Portugais",
+
+  "search.filters.language.lat": "Latin",
+
+  "search.filters.language.alg": "Langues algonquiennes",
 }

--- a/src/themes/collspec/assets/i18n/en.json5
+++ b/src/themes/collspec/assets/i18n/en.json5
@@ -93,4 +93,17 @@
  
   "collspec.page-udem": "About",
   
+  "search.filters.language.fra": "French",
+  "search.filters.language.fre": "French",
+  "search.filters.language.frm": "Middle French",
+  "search.filters.language.fro": "Old French",
+  "search.filters.language.eng": "English",
+  "search.filters.language.enm": "Middle English",
+  "search.filters.language.deu": "German",
+  "search.filters.language.spa": "Spanish",
+  "search.filters.language.ita": "Italian",
+  "search.filters.language.por": "Portuguese",
+  "search.filters.language.lat": "Latin",
+  "search.filters.language.alg": "Algonquian languages",
+  
 }

--- a/src/themes/collspec/assets/i18n/fr.json5
+++ b/src/themes/collspec/assets/i18n/fr.json5
@@ -98,5 +98,18 @@
   "subscriptions.community": "Abonnements pour les collections",
  
   "collspec.page-udem": "À propos",
-
+  
+  "search.filters.language.fra": "Français",
+  "search.filters.language.fre": "Français",
+  "search.filters.language.frm": "Français moyen",
+  "search.filters.language.fro": "Ancien français",
+  "search.filters.language.eng": "Anglais",
+  "search.filters.language.enm": "Moyen anglais",
+  "search.filters.language.deu": "Allemand",
+  "search.filters.language.spa": "Espagnol",
+  "search.filters.language.ita": "Italien",
+  "search.filters.language.por": "Portugais",
+  "search.filters.language.lat": "Latin",
+  "search.filters.language.alg": "Langues algonquiennes",
+  
 }


### PR DESCRIPTION
feat(i18n): ajout des clés de traduction pour les valeurs du filtre de langue.

Ajout des entrées de traduction sous search.filters.language.* dans le fichier de langue du thème actif afin d'afficher les noms complets des langues (ex. : "Anglais", "Français") dans la facette de recherche latérale, plutôt que les codes ISO bruts (eng, fra, etc.).