### PR TITLE
Mise à jour des libellés UI pour remplacer 'communauté' par 'collection'

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1608,9 +1608,9 @@
 
   "community.search.results.head": "Search Results",
 
-  "community.sub-collection-list.head": "Collections in this community",
+  "community.sub-collection-list.head": "Collections in this collection",
 
-  "community.sub-community-list.head": "Communities in this Community",
+  "community.sub-community-list.head": "Sub-collections in this collection",
 
   "cookies.consent.accept-all": "Accept all",
 

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -1608,9 +1608,9 @@
 
   "community.search.results.head": "Résultats de recherche",
 
-  "community.sub-collection-list.head": "Collections au sein de cette communauté",
+  "community.sub-collection-list.head": "Collections au sein de cette collection",
 
-  "community.sub-community-list.head": "Sous-communautés au sein de cette communauté",
+  "community.sub-community-list.head": "Sous-collections dans cette collection",
 
   "cookies.consent.accept-all": "Accepter tout",
 

--- a/src/themes/collspec/assets/i18n/en.json5
+++ b/src/themes/collspec/assets/i18n/en.json5
@@ -90,6 +90,8 @@
   "menu.section.browse_community": "This collection",
   "menu.section.browse_global_communities_and_collections": "Collections and sub-collections",
   "subscriptions.community": "Subscriptions for collections",
+  "community.sub-collection-list.head": "Collections in this collection",
+  "community.sub-community-list.head": "Sub-collections in this collection",
  
   "collspec.page-udem": "About",
   

--- a/src/themes/collspec/assets/i18n/fr.json5
+++ b/src/themes/collspec/assets/i18n/fr.json5
@@ -96,6 +96,8 @@
   "menu.section.browse_community": "Cette collection",
   "menu.section.browse_global_communities_and_collections": "Collections et sous-collections",
   "subscriptions.community": "Abonnements pour les collections",
+  "community.sub-collection-list.head": "Collections au sein de cette collection",
+  "community.sub-community-list.head": "Sous-collections dans cette collection",
  
   "collspec.page-udem": "À propos",
   


### PR DESCRIPTION
Mise à jour des libellés UI pour remplacer 'communauté' par 'collection'.