### PR TITLE
fix(iiif): Ajustement du mode 'vue livre'

### DIFF
--- a/src/mirador-viewer/config.local.js
+++ b/src/mirador-viewer/config.local.js
@@ -334,7 +334,7 @@ fetch(manifest)
             defaultSidebarPanelWidth: 300,
             switchCanvasOnSearch: true,
             views: [
-              { key: 'single', behaviors: ['individuals', 'paged'] },
+              { key: 'single', behaviors: ['individuals'] },
               { key: 'book', behaviors: ['paged', 'individuals'] },
               { key: 'scroll', behaviors: ['continuous'] },
               { key: 'gallery' },


### PR DESCRIPTION
Ajustement du mode 'vue livre' pour que 'iiif.viewing.hint' fonctionne correctement au niveau de l'item.