### PR TITLE
Ajout d’une page de guide IIIF et de liens dans l’en-tête

### DIFF
--- a/src/app/info/info-routes.ts
+++ b/src/app/info/info-routes.ts
@@ -20,6 +20,8 @@ import {
 } from './info-routing-paths';
 import { NotifyInfoComponent } from './notify-info/notify-info.component';
 import { ThemedPrivacyComponent } from './privacy/themed-privacy.component';
+import { IiifGuideComponent } from '../../themes/collspec/app/pages/iiif-guide/iiif-guide.component';
+import { IIIF_GUIDE_PATH } from './info-routing-paths';
 
 
 export const ROUTES: Routes = [
@@ -35,6 +37,16 @@ export const ROUTES: Routes = [
     component: AccessibilitySettingsComponent,
     resolve: { breadcrumb: i18nBreadcrumbResolver },
     data: { title: 'info.accessibility-settings.title', breadcrumbKey: 'info.accessibility-settings' },
+  },
+  // >>> NEW IIIF GUIDE ROUTE <<<
+  {
+    path: IIIF_GUIDE_PATH,
+    component: IiifGuideComponent,
+    resolve: { breadcrumb: i18nBreadcrumbResolver },
+    data: {
+      title: 'info.iiif-guide.title',
+      breadcrumbKey: 'info.iiif-guide',
+    },
   },
   environment.info.enableEndUserAgreement ? {
     path: END_USER_AGREEMENT_PATH,

--- a/src/app/info/info-routing-paths.ts
+++ b/src/app/info/info-routing-paths.ts
@@ -2,6 +2,7 @@ import { getInfoModulePath } from '../app-routing-paths';
 
 export const END_USER_AGREEMENT_PATH = 'end-user-agreement';
 export const PRIVACY_PATH = 'privacy';
+export const IIIF_GUIDE_PATH = 'iiif';
 export const FEEDBACK_PATH = 'feedback';
 export const COAR_NOTIFY_SUPPORT = 'coar-notify-support';
 export const ACCESSIBILITY_SETTINGS_PATH = 'accessibility';

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -7527,4 +7527,6 @@
   "collspec.item.handle-copied": "Link copied!",
 
   "sorting.dcterms.created.DESC": "Date Created Descending",
+
+  "collspec.menu.iiif": "IIIF Guide",
 }

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -7541,4 +7541,6 @@
   "collspec.item.handle-copied": "Lien copié !",
 
   "sorting.dcterms.created.DESC": "Date de création (décroissante)",
+
+  "collspec.menu.iiif": "Guide IIIF",
 }

--- a/src/themes/collspec/app/header/header.component.html
+++ b/src/themes/collspec/app/header/header.component.html
@@ -1,94 +1,225 @@
 <header id="main-site-header">
-  <div class="container h-100 d-flex flex-row flex-wrap align-items-center justify-content-between gapx-3 gapy-2" id="main-site-header-container">
+  <div
+    class="container h-100 d-flex flex-row flex-wrap align-items-center justify-content-between gapx-3 gapy-2"
+    id="main-site-header-container"
+  >
     <!-- Logo and navbar wrapper -->
-    <div id="header-left"
-         class="h-100 flex-fill d-flex flex-row flex-nowrap justify-content-start align-items-center gapx-3 p-2">
-        <a class="logo-brand-group" routerLink="/" [attr.aria-label]="'home.title' | translate">
-          <div class="logo-img-part">
-            <img id="header-logo" src="/assets/collspec/images/logo-bib.png" [attr.alt]="'menu.header.image.logo' | translate"/>
-          </div>
-          <div class="logo-divider"></div>
-          <span class="logo-title">Collections spéciales</span>
-        </a>
+    <div
+      id="header-left"
+      class="h-100 flex-fill d-flex flex-row flex-nowrap justify-content-start align-items-center gapx-3 p-2"
+    >
+      <a
+        class="logo-brand-group"
+        routerLink="/"
+        [attr.aria-label]="'home.title' | translate"
+      >
+        <div class="logo-img-part">
+          <img
+            id="header-logo"
+            src="/assets/collspec/images/logo-bib.png"
+            [attr.alt]="'menu.header.image.logo' | translate"
+          />
+        </div>
+        <div class="logo-divider"></div>
+        <span class="logo-title">Collections spéciales</span>
+      </a>
+
       <!-- Menu desktop - visible seulement sur écrans XL et plus -->
-      <nav class="navbar navbar-expand p-0 align-items-stretch align-self-stretch d-none d-xl-flex ml-10" id="desktop-navbar" [attr.aria-label]="'nav.main.description' | translate">
+      <nav
+        class="navbar navbar-expand p-0 align-items-stretch align-self-stretch d-none d-xl-flex ml-10"
+        id="desktop-navbar"
+        [attr.aria-label]="'nav.main.description' | translate"
+      >
         <ul class="navbar-nav mr-auto menu-collspec">
-          <!-- Nos ressources -->
+          <!-- Guide IIIF tab, BESIDE the dropdown, not inside it -->
+          <li class="nav-item">
+            <a
+              role="menuitem"
+              class="ds-menu-item"
+              href="/info/iiif"
+            >
+              {{ 'collspec.menu.iiif' | translate }}
+            </a>
+          </li>
+
+          <!-- Nos ressources / About dropdown -->
           <li class="nav-item dropdown dropdown-hover">
-            <a class="ds-menu-item dropdown-toggle-custom" role="button" aria-haspopup="true" aria-expanded="false" tabindex="0">
-              {{'collspec.menu.ressources' | translate}}
-              <span class="menu-caret" aria-hidden="true">&#9660;</span>
+            <a
+              class="ds-menu-item dropdown-toggle-custom"
+              role="button"
+              aria-haspopup="true"
+              aria-expanded="false"
+              tabindex="0"
+            >
+              {{ 'collspec.menu.ressources' | translate }}
+              <span
+                class="menu-caret"
+                aria-hidden="true"
+              >
+                &#9660;
+              </span>
             </a>
             <ul class="dropdown-menu-custom" role="menu">
-              <li role="none"><a role="menuitem" class="dropdown-item-custom" href="/page/a-propos">{{'collspec.menu.a-propos' | translate}}</a></li>
-              <li role="none"><a role="menuitem" class="dropdown-item-custom" href="/page/fonds-collections">{{'collspec.menu.fonds-collections' | translate}}</a></li>
+              <li role="none">
+                <a
+                  role="menuitem"
+                  class="dropdown-item-custom"
+                  href="/page/a-propos"
+                >
+                  {{ 'collspec.menu.a-propos' | translate }}
+                </a>
+              </li>
+              <li role="none">
+                <a
+                  role="menuitem"
+                  class="dropdown-item-custom"
+                  href="/page/fonds-collections"
+                >
+                  {{ 'collspec.menu.fonds-collections' | translate }}
+                </a>
+              </li>
             </ul>
           </li>
+
           <!-- Nous joindre -->
-          <li class="nav-item"><a role="menuitem" class="ds-menu-item" href="https://bib.umontreal.ca/nous-joindre/#lrcs">{{'collspec.menu.contact' | translate}}</a></li>
+          <li class="nav-item">
+            <a
+              role="menuitem"
+              class="ds-menu-item"
+              href="https://bib.umontreal.ca/nous-joindre/#lrcs"
+            >
+              {{ 'collspec.menu.contact' | translate }}
+            </a>
+          </li>
         </ul>
       </nav>
     </div>
 
     <!-- Search bar and other menus -->
-    <div id="header-right" class="h-100 d-flex flex-row flex-nowrap justify-content-end align-items-center gapx-1 ms-auto">
-       @if ((isMobile$ | async)!== true) {
-           <ds-search-navbar ></ds-search-navbar>
-        }
+    <div
+      id="header-right"
+      class="h-100 d-flex flex-row flex-nowrap justify-content-end align-items-center gapx-1 ms-auto"
+    >
+      @if ((isMobile$ | async) !== true) {
+        <ds-search-navbar></ds-search-navbar>
+      }
       <ds-lang-switch></ds-lang-switch>
       @if (isAuthenticated | async) {
         <ds-auth-nav-menu></ds-auth-nav-menu>
       }
-      
+
       <!-- Bouton Donate desktop -->
-      <a [href]="'collspec.donate.link' | translate"
-         class="btn btn-donate ms-2"
-         target="_blank"
-         rel="noopener noreferrer"
-         [attr.aria-label]="'collspec.donate.aria-label' | translate">
+      <a
+        [href]="'collspec.donate.link' | translate"
+        class="btn btn-donate ms-2"
+        target="_blank"
+        rel="noopener noreferrer"
+        [attr.aria-label]="'collspec.donate.aria-label' | translate"
+      >
         {{ 'collspec.donate.text' | translate }}
       </a>
 
       <!-- Bouton de menu mobile ET tablette -->
-      <div id="mobile-navbar-toggler" class="d-block d-xl-none ms-2">
-        <button id="navbar-toggler" class="btn btn-transparent" type="button" (click)="toggleNavbar()"
-                [attr.aria-label]="'nav.toggle' | translate" aria-controls="collapsible-mobile-navbar"
-                [attr.aria-expanded]="(isNavBarCollapsed$ | async) !== true">
-          <span class="fas fa-bars fa-fw fa-xl toggler-icon" aria-hidden="true"></span>
+      <div
+        id="mobile-navbar-toggler"
+        class="d-block d-xl-none ms-2"
+      >
+        <button
+          id="navbar-toggler"
+          class="btn btn-transparent"
+          type="button"
+          (click)="toggleNavbar()"
+          [attr.aria-label]="'nav.toggle' | translate"
+          aria-controls="collapsible-mobile-navbar"
+          [attr.aria-expanded]="(isNavBarCollapsed$ | async) !== true"
+        >
+          <span
+            class="fas fa-bars fa-fw fa-xl toggler-icon"
+            aria-hidden="true"
+          ></span>
         </button>
       </div>
     </div>
 
     <!-- Mobile & Tablet Navbar -->
     <div class="w-100 order-last d-xl-none">
-      <nav id="collapsible-mobile-navbar" class="collapse" [ngClass]="{'show': !(isNavBarCollapsed$ | async)}">
+      <nav
+        id="collapsible-mobile-navbar"
+        class="collapse"
+        [ngClass]="{'show': !(isNavBarCollapsed$ | async)}"
+      >
         <ul class="navbar-nav mr-auto menu-collspec text-start">
           <!-- Nos ressources (dépliable) -->
           <li class="nav-item nav-item-browse-toggle">
-            <button type="button" class="ds-menu-item btn-browse-mobile w-100 text-start d-flex justify-content-between align-items-center"
-                    (click)="toggleMobileRessources()"
-                    [attr.aria-expanded]="isMobileRessourcesOpen">
-              {{'collspec.menu.ressources' | translate}}
-              <span class="menu-caret-mobile" [class.open]="isMobileRessourcesOpen" aria-hidden="true">&#9660;</span>
+            <button
+              type="button"
+              class="ds-menu-item btn-browse-mobile w-100 text-start d-flex justify-content-between align-items-center"
+              (click)="toggleMobileRessources()"
+              [attr.aria-expanded]="isMobileRessourcesOpen"
+            >
+              {{ 'collspec.menu.ressources' | translate }}
+              <span
+                class="menu-caret-mobile"
+                [class.open]="isMobileRessourcesOpen"
+                aria-hidden="true"
+              >
+                &#9660;
+              </span>
             </button>
           </li>
+
           @if (isMobileRessourcesOpen) {
             <li class="nav-item nav-item-browse-sub">
-              <a role="menuitem" class="ds-menu-item ds-menu-item-sub" href="/page/a-propos">{{'collspec.menu.a-propos' | translate}}</a>
+              <a
+                role="menuitem"
+                class="ds-menu-item ds-menu-item-sub"
+                href="/page/a-propos"
+              >
+                {{ 'collspec.menu.a-propos' | translate }}
+              </a>
             </li>
             <li class="nav-item nav-item-browse-sub">
-              <a role="menuitem" class="ds-menu-item ds-menu-item-sub" href="/page/fonds-collections">{{'collspec.menu.fonds-collections' | translate}}</a>
+              <a
+                role="menuitem"
+                class="ds-menu-item ds-menu-item-sub"
+                href="/page/fonds-collections"
+              >
+                {{ 'collspec.menu.fonds-collections' | translate }}
+              </a>
             </li>
           }
+
+          <!-- TOP-LEVEL: Guide IIIF (mobile), outside the @if block -->
+          <li class="nav-item">
+            <a
+              role="menuitem"
+              class="ds-menu-item"
+              href="/info/iiif"
+            >
+              {{ 'collspec.menu.iiif' | translate }}
+            </a>
+          </li>
+
           <!-- Nous joindre -->
-          <li class="nav-item"><a role="menuitem" class="ds-menu-item" href="https://bib.umontreal.ca/nous-joindre/#lrcs">{{'collspec.menu.contact'| translate}}</a></li>
+          <li class="nav-item">
+            <a
+              role="menuitem"
+              class="ds-menu-item"
+              href="https://bib.umontreal.ca/nous-joindre/#lrcs"
+            >
+              {{ 'collspec.menu.contact' | translate }}
+            </a>
+          </li>
+
           <!-- Bouton Donate mobile -->
           <li class="nav-item nav-item-donate">
-            <a [href]="'collspec.donate.link' | translate"
-               class="btn btn-donate-mobile"
-               target="_blank"
-               rel="noopener noreferrer"
-               [attr.aria-label]="'collspec.donate.aria-label' | translate">
+            <a
+              [href]="'collspec.donate.link' | translate"
+              class="btn btn-donate-mobile"
+              target="_blank"
+              rel="noopener noreferrer"
+              [attr.aria-label]="'collspec.donate.aria-label' | translate"
+            >
               {{ 'collspec.donate.text' | translate }}
             </a>
           </li>

--- a/src/themes/collspec/app/pages/iiif-guide/iiif-guide.component.html
+++ b/src/themes/collspec/app/pages/iiif-guide/iiif-guide.component.html
@@ -1,0 +1,144 @@
+<div class="iiif-guide-page">
+
+  <!-- ===== Page title ===== -->
+  <div class="iiif-intro">
+    <h1>Utiliser IIIF avec les Collections spéciales</h1>
+    <p class="bib-description">
+      Cette page explique comment utiliser le standard IIIF pour explorer, comparer et réutiliser
+      les documents numérisés des Collections spéciales, dans des visionneuses comme Mirador et dans
+      d’autres outils compatibles.
+    </p>
+  </div>
+
+  <!-- ===== Section A : Qu’est-ce que IIIF ? ===== -->
+  <section class="iiif-section">
+    <h2 class="h2-bib-titre">Qu’est-ce que IIIF&nbsp;?</h2>
+    <p class="bib-description">
+      IIIF (International Image Interoperability Framework) est un ensemble de standards ouverts
+      pour la diffusion d’images et de documents numériques de haute qualité sur le web. Il permet
+      aux bibliothèques et aux archives de publier leurs contenus de manière interopérable, afin
+      qu’ils puissent être visualisés et réutilisés dans une variété d’outils.
+    </p>
+    <p class="bib-description">
+      Sur cette plateforme, IIIF vous donne accès à des images zoomables, comparables et annotables,
+      que vous pouvez intégrer dans des projets de recherche, des travaux universitaires ou des
+      activités d’enseignement.
+    </p>
+  </section>
+
+  <!-- ===== Section B : Repérer IIIF sur les pages de documents ===== -->
+  <section class="iiif-section">
+    <h2 class="h2-bib-titre">Repérer IIIF sur les pages de documents</h2>
+    <p class="bib-description">
+      Plusieurs documents des Collections spéciales sont accompagnés d’un lien ou d’une icône IIIF
+      sur leur page de notice. Ce lien mène vers un manifeste IIIF, c’est-à-dire un fichier de
+      description qui contient la structure du document (pages, séquences), ses métadonnées et les
+      liens vers les images numériques.
+    </p>
+
+    <h3 class="h3-bib-soustitre">Étape&nbsp;1&nbsp;: Trouver le lien ou le logo IIIF</h3>
+    <p class="bib-description">
+      Sur la page d’un document, cherchez le logo IIIF ou un lien intitulé «&nbsp;Manifeste IIIF&nbsp;»,
+      «&nbsp;IIIF manifest&nbsp;» ou «&nbsp;Ouvrir dans une visionneuse IIIF&nbsp;», généralement près
+      de la zone d’affichage des images.
+    </p>
+
+    <h3 class="h3-bib-soustitre">Étape&nbsp;2&nbsp;: Copier l’URL du manifeste</h3>
+    <p class="bib-description">
+      En cliquant sur ce lien, votre navigateur affiche un fichier texte au format JSON. Vous n’avez
+      pas besoin de comprendre ce code&nbsp;: l’élément important est l’adresse dans la barre
+      d’URL. Copiez cette adresse&nbsp;: c’est l’URL du manifeste IIIF que vous pourrez coller dans
+      une visionneuse ou un autre outil compatible.
+    </p>
+  </section>
+
+  <!-- ===== Section C : Visualiser les documents avec Mirador ===== -->
+  <section class="iiif-section">
+    <h2 class="h2-bib-titre">Visualiser les documents avec Mirador</h2>
+    <p class="bib-description">
+      Mirador est une visionneuse IIIF libre qui permet d’afficher et de comparer plusieurs documents
+      côte à côte, de zoomer dans les détails et, selon la configuration, d’annoter les images.
+      Il est largement utilisé dans les bibliothèques de recherche et les humanités numériques.
+    </p>
+
+    <h3 class="h3-bib-soustitre">Ouvrir un manifeste IIIF dans Mirador</h3>
+    <p class="bib-description">
+      Pour explorer un document des Collections spéciales dans Mirador&nbsp;:
+    </p>
+    <ul class="bib-description">
+      <li>Copiez l’URL du manifeste IIIF depuis la page du document.</li>
+      <li>Ouvrez votre instance Mirador (locale ou en ligne).</li>
+      <li>Cliquez sur le bouton pour ajouter une ressource (par ex. «&nbsp;+ Add Resource&nbsp;»).</li>
+      <li>Collez l’URL du manifeste IIIF et validez.</li>
+    </ul>
+    <p class="bib-description">
+      Le document s’affiche alors dans Mirador. Vous pouvez ajouter d’autres manifestes IIIF pour
+      comparer plusieurs documents, changer le mode d’affichage (page, livre, galerie) ou utiliser
+      les outils intégrés pour annoter et analyser les images.
+    </p>
+  </section>
+
+  <!-- ===== Section D : Enseignement et récits numériques ===== -->
+  <section class="iiif-section">
+    <h2 class="h2-bib-titre">Enseignement et récits numériques</h2>
+    <p class="bib-description">
+      Les enseignants et enseignantes peuvent utiliser IIIF pour préparer des séances de cours en
+      plaçant plusieurs images sur un même écran, en zoomant sur des détails significatifs et en
+      invitant les étudiantes et étudiants à comparer des documents provenant de différentes
+      institutions.
+    </p>
+    <p class="bib-description">
+      Des plateformes de narration numérique compatibles IIIF permettent également de créer des
+      expositions virtuelles, des essais illustrés ou des parcours thématiques à partir de documents
+      des Collections spéciales, tout en respectant leur contexte et leurs métadonnées.
+    </p>
+  </section>
+
+  <!-- ===== Section E : Informations techniques pour développeurs ===== -->
+  <section class="iiif-section">
+    <h2 class="h2-bib-titre">Informations techniques pour développeurs</h2>
+    <p class="bib-description">
+      Un manifeste IIIF est un fichier JSON structuré qui décrit un objet numérique&nbsp;: séquences
+      de pages (canvases), images associées, métadonnées descriptives et liens vers d’autres
+      ressources. Les manifestes publiés par cette plateforme suivent le format défini par la
+      spécification IIIF Presentation API.
+    </p>
+    <p class="bib-description">
+      Pour les développeurs et développeuses, les manifestes peuvent être intégrés dans des outils
+      d’annotation, de visualisation comparative, de recadrage (cropping) ou dans des applications
+      web personnalisées. Pour en savoir plus, consultez la documentation et les recettes du site
+      officiel IIIF (<a href="https://iiif.io" target="_blank" rel="noopener">iiif.io</a>).
+    </p>
+  </section>
+
+  <!-- ===== Section F : Citer et réutiliser les documents ===== -->
+  <section class="iiif-section">
+    <h2 class="h2-bib-titre">Citer et réutiliser les documents</h2>
+    <p class="bib-description">
+      Lorsque vous utilisez des images ou des documents issus des Collections spéciales dans des
+      travaux, des publications ou des projets numériques, vous devez toujours citer la source,
+      incluant la mention des bibliothèques de l’Université de Montréal et l’URL de la notice du
+      document sur cette plateforme.
+    </p>
+    <p class="bib-description">
+      Les conditions d’utilisation, licences et mentions de droits indiquées sur la page de chaque
+      document s’appliquent également aux contenus IIIF. Toute utilisation commerciale ou diffusion
+      massive doit faire l’objet d’une autorisation spécifique.
+    </p>
+  </section>
+
+  <!-- ===== Section G : Essayer IIIF avec des exemples ===== -->
+  <section class="iiif-section iiif-section-examples">
+    <h2 class="h2-bib-titre">Essayer IIIF avec des exemples</h2>
+    <p class="bib-description">
+      Pour vous familiariser avec IIIF, vous pouvez commencer par quelques documents de démonstration.
+      Copiez l’URL de leur manifeste IIIF, ouvrez une visionneuse compatible (comme Mirador) et
+      explorez les images, les métadonnées et les différentes vues possibles.
+    </p>
+    <p class="bib-description">
+      Bientôt, cette section proposera une sélection d’exemples issus des Collections spéciales pour
+      vous permettre de tester les fonctionnalités IIIF et de les intégrer à vos projets.
+    </p>
+  </section>
+
+</div>

--- a/src/themes/collspec/app/pages/iiif-guide/iiif-guide.component.scss
+++ b/src/themes/collspec/app/pages/iiif-guide/iiif-guide.component.scss
@@ -1,0 +1,54 @@
+// Basic layout for the IIIF guide page.
+// You can also import shared variables/mixins from your theme if needed.
+
+.iiif-guide-page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+
+  // Optional background/spacing to visually differentiate the guide
+  background-color: #f8f9fa;
+}
+
+.iiif-intro {
+  margin-bottom: 2rem;
+
+  h1 {
+    font-size: 2.2rem;
+    margin-bottom: 0.75rem;
+  }
+}
+
+.iiif-section {
+  margin-bottom: 2.5rem;
+
+  .h2-bib-titre {
+    font-size: 1.6rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .h3-bib-soustitre {
+    font-size: 1.3rem;
+    margin-top: 1.25rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .bib-description {
+    margin-bottom: 0.75rem;
+    line-height: 1.5;
+  }
+
+  ul.bib-description {
+    padding-left: 1.25rem;
+    margin-bottom: 0.75rem;
+
+    li {
+      margin-bottom: 0.35rem;
+    }
+  }
+}
+
+.iiif-section-examples {
+  border-top: 1px solid #dee2e6;
+  padding-top: 1.5rem;
+}

--- a/src/themes/collspec/app/pages/iiif-guide/iiif-guide.component.ts
+++ b/src/themes/collspec/app/pages/iiif-guide/iiif-guide.component.ts
@@ -1,0 +1,27 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { ThemedLoadingComponent } from '../../../../../app/shared/loading/themed-loading.component';
+
+@Component({
+  selector: 'ds-iiif-guide',
+  templateUrl: './iiif-guide.component.html',
+  styleUrls: ['./iiif-guide.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    TranslateModule,
+    NgbModule,
+    ThemedLoadingComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class IiifGuideComponent {
+  // For now, this page is purely static.
+  // If you later want per-language variants, you can
+  // adopt the same asset-loading pattern as AboutComponent.
+}

--- a/src/themes/collspec/assets/i18n/en.json5
+++ b/src/themes/collspec/assets/i18n/en.json5
@@ -151,4 +151,6 @@
   "search.filters.language.lat": "Latin",
   "search.filters.language.alg": "Algonquian languages",
   
+  "collspec.menu.iiif": "IIIF Guide",
+  
 }

--- a/src/themes/collspec/assets/i18n/fr.json5
+++ b/src/themes/collspec/assets/i18n/fr.json5
@@ -160,4 +160,6 @@
   "search.filters.language.lat": "Latin",
   "search.filters.language.alg": "Langues algonquiennes",
   
+  "collspec.menu.iiif": "Guide IIIF",
+  
 }


### PR DESCRIPTION
- Ajout du composant `IiifGuideComponent` dans le thème Collspec
- Déclaration de la route `/info/iiif` dans le module d’information
- Ajout de l’onglet « Guide IIIF » dans l’en-tête (version bureau)
- Ajout du lien « Guide IIIF » dans le menu de navigation mobile
- Mise à jour des traductions avec la clé `collspec.menu.iiif`